### PR TITLE
Move 'Entry Done' note under date column

### DIFF
--- a/frontend/src/components/modals/LeadModal.tsx
+++ b/frontend/src/components/modals/LeadModal.tsx
@@ -373,7 +373,12 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
             <tbody>
               {noteHistory.map((entry, i) => (
                 <tr key={i} className="border-b border-gray-700">
-                  <td className="p-2 text-gray-400">{new Date(entry.date).toLocaleString()}</td>
+                  <td className="p-2 text-gray-400">
+                    {new Date(entry.date).toLocaleString()}
+                    {!entry.isNew && (
+                      <span className="block text-xs text-green-400">Entry Done</span>
+                    )}
+                  </td>
                   <td className="p-2">
                     <select
                       className="form-input"
@@ -406,9 +411,6 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
                       onChange={(e) => handleNoteChange(i, 'note', e.target.value)}
                       disabled={role === 'relationship_mgr' && !entry.isNew}
                     />
-                    {!entry.isNew && (
-                      <span className="ml-2 text-xs text-green-400">Entry Done</span>
-                    )}
                   </td>
                 </tr>
               ))}


### PR DESCRIPTION
## Summary
- reposition the "Entry Done" indicator in the lead edit modal so it shows under the date and time column

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688b16f81ec483289e8c112a543f6bcf