### PR TITLE
Fix blank note row in LeadModal

### DIFF
--- a/frontend/src/components/modals/LeadModal.tsx
+++ b/frontend/src/components/modals/LeadModal.tsx
@@ -75,15 +75,10 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
             };
           }) || [];
 
-      setNoteHistory([
-        {
-          note: '',
-          status: lead.status || 'New',
-          date: new Date().toISOString(),
-          isNew: true,
-        },
-        ...history.reverse(),
-      ]);
+      // For existing leads, just populate the saved history without
+      // automatically adding a new empty row. Users can add a row
+      // manually using the "+ Add Row" button.
+      setNoteHistory(history.reverse());
     } else {
       setFormData({
         fullName: '',


### PR DESCRIPTION
## Summary
- avoid auto-adding an empty note entry when editing leads

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_e_688b2c406bcc8328bdff5ca043c1d372